### PR TITLE
Include config-file to plugins

### DIFF
--- a/plugin_test/config/config.ini
+++ b/plugin_test/config/config.ini
@@ -1,0 +1,22 @@
+########################
+# BOSWatch Config File #
+########################
+
+#can take on or off the modules (0|1)
+[Module]
+MySQL = 0
+HTTPrequest = 0
+BosMon = 0
+# for developing template-module is enabled
+template = 1
+
+[BosMon]
+#Server as IP of DNS-Name (without http://)
+#actually no ssl supported
+bosmon_server = 192.168.0.1
+bosmon_port = 80
+#channel-name of typ "Web-Telegramm"
+bosmon_channel = channelname
+#Use this, when you have security enabled
+bosmon_user = user
+bosmon_password = password

--- a/plugin_test/globals.py
+++ b/plugin_test/globals.py
@@ -1,0 +1,5 @@
+#!/usr/bin/python
+# -*- coding: cp1252 -*-
+
+#Global variables
+config = 0


### PR DESCRIPTION
- insert globals for logging and config
- insert configuration-file
- pluginloader use only enabled modules (config.ini)
