### PR TITLE
Update config.template.ini

### DIFF
--- a/config/config.template.ini
+++ b/config/config.template.ini
@@ -136,6 +136,7 @@ Sms77 = 0
 FFAgent = 0
 Pushover = 0
 Telegram = 0
+yowsup = 0
 
 # for developing template-module
 template = 0


### PR DESCRIPTION
Added forgotten plugin switch for yowsup due to errors while BOSWatch misses it during startup

Should be added to version 2.1 as a hotfix due to problems while starting up plugin-loader.