### PR TITLE
Update eMail.py

### DIFF
--- a/plugins/eMail/eMail.py
+++ b/plugins/eMail/eMail.py
@@ -111,7 +111,7 @@ def run(typ,freq,data):
 				server.set_debuglevel(0)
 
 				# if tls is enabled, starttls
-				if globalVars.config.get("eMail", "tls"):
+				if globalVars.config.getboolean("eMail", "tls"):
 					server.starttls()
 
 				# if user is given, login

--- a/plugins/eMail/eMail.py
+++ b/plugins/eMail/eMail.py
@@ -103,7 +103,10 @@ def run(typ,freq,data):
 				#
 				# connect to SMTP-Server
 				#
-				server = smtplib.SMTP_SSL(globalVars.config.get("eMail", "smtp_server"), globalVars.config.get("eMail", "smtp_port"))
+				try:
+					server = smtplib.SMTP_SSL(globalVars.config.get("eMail", "smtp_server"), globalVars.config.get("eMail", "smtp_port"))
+				except:
+					server = smtplib.SMTP(globalVars.config.get("eMail", "smtp_server"), globalVars.config.get("eMail", "smtp_port"))
 				# debug-level to shell (0=no debug|1)
 				server.set_debuglevel(0)
 


### PR DESCRIPTION
Using only SMTP via SSL can lead to errors depending on the configuration of the mail server
As there is no switch in the config file (which is good so) the approach is to use SSL first and, if this fails, switch to non-SSL connection.

Due to the importance of this plugin the pull request is affecting the master-branch.