### PR TITLE
renamed module bash to base

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ before_script:
   - sudo ./install.sh -b ${TRAVIS_BRANCH}
 
 env:
-  - module=bash
+  - module=base
   - module=mysql
   - module=httpRequest
 


### PR DESCRIPTION
In travis.yml heißt das module=bash.
In citest/test.sh heißt es module=base.

Da war der Fehler ...