### PR TITLE
Switching mm_raw to off by default

### DIFF
--- a/config/config.template.ini
+++ b/config/config.template.ini
@@ -49,7 +49,7 @@ doubleFilter_ignore_time = 5
 doubleFilter_check_msg = 0
 
 # writes the multimon-ng raw data stream into a text file named mm_raw.txt
-writeMultimonRaw = 1
+writeMultimonRaw = 0
 
 [NMAHandler]
 # you can use a logging handler for sending logging records to NotifyMyAndroid


### PR DESCRIPTION
As it's mainly for debug-reasons, there is no need to enable the mm_raw-out by default.