### PR TITLE
Feature: SubRIC für die Beschreibung berücksichtigen

### DIFF
--- a/includes/decoders/poc.py
+++ b/includes/decoders/poc.py
@@ -126,7 +126,7 @@ def decode(freq, decoded):
 						# If enabled, look up description
 						if globalVars.config.getint("POC", "idDescribed"):
 							from includes import descriptionList
-							data["description"] = descriptionList.getDescription("POC", poc_id)
+							data["description"] = descriptionList.getDescription("POC", poc_id+poc_sub)
 						# processing the alarm
 						try:
 							from includes import alarmHandler

--- a/includes/decoders/poc.py
+++ b/includes/decoders/poc.py
@@ -126,7 +126,7 @@ def decode(freq, decoded):
 						# If enabled, look up description
 						if globalVars.config.getint("POC", "idDescribed"):
 							from includes import descriptionList
-							data["description"] = descriptionList.getDescription("POC", poc_id+poc_sub)
+							data["description"] = descriptionList.getDescription("POC", poc_id+data["functionChar"])
 						# processing the alarm
 						try:
 							from includes import alarmHandler

--- a/includes/descriptionList.py
+++ b/includes/descriptionList.py
@@ -43,7 +43,7 @@ def loadCSV(typ, idField):
 			for row in reader:
 				logging.debug(row)
 				# only import rows with an integer as id, allow subrics though
-				if re.match("^[0-9]+[A-D]?$", idField, re.IGNORECASE):
+				if re.match("^[0-9]+[A-D]?$", row[idField], re.IGNORECASE):
 					try:
 						resultList[row[idField]] = stringConverter.convertToUTF8(row['description'])
 					except:

--- a/includes/descriptionList.py
+++ b/includes/descriptionList.py
@@ -45,11 +45,7 @@ def loadCSV(typ, idField):
 				# only import rows with an integer as id, allow subrics though
 				if re.match("^[0-9]+[A-D]?$", row[idField], re.IGNORECASE):
 					try:
-						if len(row[idField]) > 7:
-							if row[idField][7].isupper():
-								tmp = row[idField].lower()
-								row[idField] = tmp;
-						resultList[row[idField]] = stringConverter.convertToUTF8(row['description'])
+						resultList[row[idField].lower()] = stringConverter.convertToUTF8(row['description'])
 					except:
 						# skip entry in case of an exception
 						pass

--- a/includes/descriptionList.py
+++ b/includes/descriptionList.py
@@ -113,6 +113,8 @@ def getDescription(typ, data):
 		elif typ == "POC":
 			global ricDescribtionList
 			resultStr = ricDescribtionList[data]
+			if not resultStr:
+				resultStr = ricDescribtionList[data[:-1]]
 		else:
 			logging.warning("Invalid Typ: %s", typ)
 

--- a/includes/descriptionList.py
+++ b/includes/descriptionList.py
@@ -11,6 +11,7 @@ Function to expand the dataset with a description.
 
 import logging # Global logger
 import csv # for loading the description files
+import re # for matching IDs with a regular expression
 
 from includes import globalVars  # Global variables
 from includes.helper import stringConverter
@@ -41,8 +42,8 @@ def loadCSV(typ, idField):
 			reader = csv.DictReader(csvfile)
 			for row in reader:
 				logging.debug(row)
-				# only import rows with an integer as id
-				if row[idField].isdigit() == True:
+				# only import rows with an integer as id, allow subrics though
+				if re.match("^[0-9]+[A-D]?$", idField, re.IGNORECASE):
 					try:
 						resultList[row[idField]] = stringConverter.convertToUTF8(row['description'])
 					except:

--- a/includes/descriptionList.py
+++ b/includes/descriptionList.py
@@ -45,6 +45,10 @@ def loadCSV(typ, idField):
 				# only import rows with an integer as id, allow subrics though
 				if re.match("^[0-9]+[A-D]?$", row[idField], re.IGNORECASE):
 					try:
+						if len(row[idField]) > 7:
+							if row[idField][7].isupper():
+								tmp = row[idField].lower()
+								row[idField] = tmp;
 						resultList[row[idField]] = stringConverter.convertToUTF8(row['description'])
 					except:
 						# skip entry in case of an exception

--- a/includes/descriptionList.py
+++ b/includes/descriptionList.py
@@ -113,9 +113,8 @@ def getDescription(typ, data):
 			resultStr = zveiDescribtionList[data]
 		elif typ == "POC":
 			global ricDescribtionList
-			resultStr = ricDescribtionList[data]
-			if not resultStr:
-				resultStr = ricDescribtionList[data[:-1]]
+			resultStr = ricDescribtionList[data[:-1]] # MainRIC
+			resultStr += " " + ricDescribtionList[data] # SubRIC
 		else:
 			logging.warning("Invalid Typ: %s", typ)
 


### PR DESCRIPTION
Habe das mal in ganz einfacher Weise implementiert.

Der Code ist - mangels Hardware - **nicht getestet**. Insbesondere die Annahme des Wertebereich (0-9) für eine SubRIC ist fraglich.

~~poc.csv:~~ (siehe https://github.com/Schrolli91/BOSWatch/pull/271#issuecomment-297913819)
```csv
1234567,"FF XYZ Fallback"
12345671,"FF XYZ Zug 1"
12345672,"FF XYZ Zug 2"
```
Für Feedback bin ich dankbar.

#265 #191 
