### PR TITLE
Record plugin

### DIFF
--- a/boswatch.py
+++ b/boswatch.py
@@ -18,11 +18,12 @@ GitHUB:		https://github.com/Schrolli91/BOSWatch
 import logging
 import logging.handlers
 
-import argparse     # for parse the args
-import ConfigParser # for parse the config file
-import os           # for log mkdir
-import time         # for time.sleep()
-import subprocess   # for starting rtl_fm and multimon-ng
+import argparse		# for parse the args
+import ConfigParser	# for parse the config file
+import os			# for log mkdir
+import sys			# for py version
+import time			# for time.sleep()
+import subprocess	# for starting rtl_fm and multimon-ng
 
 from includes import globalVars  # Global variables
 from includes import MyTimedRotatingFileHandler  # extension of TimedRotatingFileHandler
@@ -56,7 +57,7 @@ try:
 	parser.add_argument("-u", "--usevarlog", help="Use '/var/log/boswatch' for logfiles instead of subdir 'log' in BOSWatch directory", action="store_true")
 	parser.add_argument("-v", "--verbose", help="Show more information", action="store_true")
 	parser.add_argument("-q", "--quiet", help="Show no information. Only logfiles", action="store_true")
-	
+
 	# We need this argument for testing (skip instantiate of rtl-fm and multimon-ng):
 	parser.add_argument("-t", "--test", help=argparse.SUPPRESS, action="store_true")
 	args = parser.parse_args()
@@ -163,7 +164,10 @@ try:
 	#
 	try:
 		logging.debug("SW Version:	%s",globalVars.versionNr)
+		logging.debug("Branch:		%s",globalVars.branch)
 		logging.debug("Build Date:	%s",globalVars.buildDate)
+		logging.debug("Python Vers:	%s",sys.version)
+
 		logging.debug("BOSWatch given arguments")
 		if args.test:
 			logging.debug(" - Test-Mode!")
@@ -221,6 +225,9 @@ try:
 			configHandler.checkConfig("FMS")
 			configHandler.checkConfig("ZVEI")
 			configHandler.checkConfig("POC")
+			configHandler.checkConfig("Plugins")
+			configHandler.checkConfig("Filters")
+			#NMAHandler is outputed below
 	except:
 		# we couldn't work without config -> exit
 		logging.critical("cannot read config file")
@@ -329,13 +336,13 @@ try:
 		logging.critical("cannot start rtl_fm")
 		logging.debug("cannot start rtl_fm", exc_info=True)
 		exit(1)
-	
+
 	#duplicate rtl_fm stdout for the record plugin and multimon-ng
 	pipe_r, pipe_w = os.pipe()
 	tee = subprocess.Popen(["tee", "/dev/fd/{}".format(pipe_w)],
             stdin=rtl_fm.stdout, stdout=subprocess.PIPE)
 
-	
+
 	#
 	# Start audioplaybackstream for the record plugin
 	#
@@ -359,11 +366,11 @@ try:
 			exit(1)
 	else:
 		logging.debug("record plugin not activated. activate it in the config.ini")
-		
+
 	#
 	# Start multimon
 	#
-	
+
 	try:
 		if not args.test:
 			logging.debug("starting multimon-ng")

--- a/config/config.template.ini
+++ b/config/config.template.ini
@@ -163,6 +163,7 @@ FFAgent = 0
 Pushover = 0
 Telegram = 0
 yowsup = 0
+record = 0
 
 # for developing - template-module
 template = 0
@@ -413,6 +414,11 @@ zvei_message = %DATE% %TIME%: %ZVEI%
 #Wildcards can be used, see end of the file!
 poc_message = %MSG%
 
+
+[record]
+#duration in seconds
+rec_duration = 40
+#filepath = #INSERT FILE PATH HERE# ex: /home/user/BOSWatch/recordings/ 
 
 #####################
 ##### Not ready yet #

--- a/includes/globalVars.py
+++ b/includes/globalVars.py
@@ -8,10 +8,10 @@ Global variables
 @author: Bastian Schroll
 """
 
+# version info
 versionNr = "2.3"
 branch = "dev"
 buildDate = "unreleased"
-
 
 # Global variables
 config = 0

--- a/plugins/record/record.py
+++ b/plugins/record/record.py
@@ -1,0 +1,118 @@
+#!/usr/bin/python
+# -*- coding: UTF-8 -*-
+
+"""
+
+@author: DK5RA Alex(trollkopp)
+
+@requires: arecord >= 1.1.3 
+"""
+
+# ADD THIS TO YOUR Pulseaudio config file /etc/pulse/default.pa
+# load-module module-null-sink sink_name=playbackstream
+# update-sink-proplist playbackstream device.description=playbackstream
+# load-module module-loopback sink=playbackstream
+# set-default-sink playbackstream
+# set-default-source playbackstream.monitor
+
+
+#
+# Imports
+#
+
+import logging # Global logger
+from includes import globalVars  # Global variables
+
+
+import os           # for log mkdir
+import time         # for time.sleep()
+import subprocess   # for starting record
+
+# Helper function, uncomment to use
+from includes.helper import timeHandler
+from includes.helper import wildcardHandler
+from includes.helper import configHandler
+
+##
+#
+# onLoad (init) function of plugin
+# will be called one time by the pluginLoader on start
+#
+def onLoad():
+	"""
+	While loading the plugins by pluginLoader.loadPlugins()
+	this onLoad() routine is called one time for initialize the plugin
+
+	@requires:  nothing
+
+	@return:    nothing
+	@exception: Exception if init has an fatal error so that the plugin couldn't work
+
+	"""
+	
+	try:
+		########## User onLoad CODE ##########
+		pass
+		########## User onLoad CODE ##########
+	except:
+		logging.error("unknown error")
+		logging.debug("unknown error", exc_info=True)
+		raise
+
+##
+#
+# Main function of plugin
+# will be called by the alarmHandler
+#
+def run(typ,freq,data):
+	"""
+	This function is the implementation of the Plugin.
+
+	If necessary the configuration hast to be set in the config.ini.
+
+	@type    typ:  string (FMS|ZVEI|POC)
+	@param   typ:  Typ of the dataset
+	@type    data: map of data (structure see readme.md in plugin folder)
+	@param   data: Contains the parameter for dispatch
+	@type    freq: string
+	@keyword freq: frequency of the SDR Stick
+
+	@requires:  If necessary the configuration hast to be set in the config.ini.
+
+	@return:    nothing
+	@exception: nothing, make sure this function will never thrown an exception
+	"""
+	try:
+		if configHandler.checkConfig("record"): #read and debug the config (let empty if no config used)
+
+			logging.debug(globalVars.config.get("Plugins", "record"))
+#			logging.debug(globalVars.config.get("template", "test2"))
+			rec_duration = globalVars.config.get("record", "rec_duration")
+			if (globalVars.config.get("Plugins", "record") == "1"):
+				########## User Plugin CODE ##########
+				if typ == "FMS":
+					logging.warning("%s not supported", typ)
+				elif typ == "ZVEI":
+					logging.debug("record plugin: detected ZVEI decode")
+					timestamp = str(timeHandler.getDate())+"-"+str(timeHandler.getTime())
+					zveicode = "%ZVEI%"
+					zveicode = wildcardHandler.replaceWildcards(zveicode, data)
+					filename = "aufnahme_"+"5-ton"+str(zveicode)+"_"+str(timestamp)+".wav"
+					rec_filepath = globalVars.config.get("record", "filepath")
+					logging.debug(filename)
+					logging.debug(rec_filepath)
+					command = ""
+					command = command+"arecord -D pulse -f cd -d "+str(rec_duration)+" -c 1 "+str(rec_filepath)+str(filename)+""
+					recordstream = subprocess.Popen(command.split(),
+					stderr=open(globalVars.log_path+"record.log","a"),
+					shell=False)
+				elif typ == "POC":
+					logging.warning("%s not supported", typ)
+				else:
+					logging.warning("Invalid Typ: %s", typ)
+				########## User Plugin CODE ##########
+			else:
+				logging.debug("record plugin not activated. activate it in the config.ini")
+	except:
+		logging.error("unknown error")
+		logging.debug("unknown error", exc_info=True)


### PR DESCRIPTION
Short and dirty record-plugin which records into a directory a wave file with a specified time(config file)

to use it its important to use pulseaudio
# ADD THIS TO YOUR Pulseaudio config file /etc/pulse/default.pa
load-module module-null-sink sink_name=playbackstream
update-sink-proplist playbackstream device.description=playbackstream
load-module module-loopback sink=playbackstream
set-default-sink playbackstream
set-default-source playbackstream.monitor

Created a copy of the rtl_fm.stdout pipe and piped it to paplay and multimon-ng
aplay playes the sound to the default sink and parecord records from the default sink

WARNING: on the alsa-utils standard rpi deb 1.0.28 parecord does not quit byself and create many useless files. I tested 1.1.13 and 1.1.14. You can compile that quick an the rpi

To access to the records you can setup a "cloud" like seafile,owncloud,syncthing and so on and access from the mobile to it. Did not implement some sending feature for telegram,email or so. Because you need to wait until the recording is finished and then send it. Could implement but this would be a very very dirty script maybe some of you have a idea

feel free to be critical and discuss