### PR TITLE
Enhancement for multicastAlarm. The RICs configured in multicastAlarm…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,13 @@
 - FMS und ZVEI Support für Pushover Plugin [#352](https://github.com/Schrolli91/BOSWatch/pull/352)
 - Benutzerdefinierte Nachrichten für Pushover Plugin in config [#352](https://github.com/Schrolli91/BOSWatch/pull/352)
 ##### Changed
+- multicastAlarm Plugin - RICs die von multicastAlarm genutzt werden, müssen nicht mehr in der config bei allow_ric bzw. filter_range_start/filter_range_end berücksichtigt werden. [#357](https://github.com/Schrolli91/BOSWatch/pull/357)
+- FFAgent Plugin - Debug Logging für die alarmHeaders eingebaut zwecks Troubleshooting [#354](https://github.com/Schrolli91/BOSWatch/pull/354)
 ##### Deprecated
 ##### Removed
 ##### Fixed
 - Fehler beim Auslesen der netIdent_RIC im MySQL Plugin [#347](https://github.com/Schrolli91/BOSWatch/pull/347)
+- FFAgent Plugin - Typo bei alarmHeaders für Live Betrieb gefixt [#354](https://github.com/Schrolli91/BOSWatch/pull/354)
 ##### Security
 
 

--- a/includes/decoders/poc.py
+++ b/includes/decoders/poc.py
@@ -62,11 +62,23 @@ def isAllowed(poc_id):
 			return True
 		else:
 			allowed = 0
+	# 5.) Implementation for multicastAlarm
+	if globalVars.config.get("multicastAlarm", "multicastAlarm_delimiter_ric"):
+		if poc_id in globalVars.config.get("multicastAlarm", "multicastAlarm_delimiter_ric"):
+			logging.info("RIC %s as multicastAlarm delimiter", poc_id)
+			return True
+		else:
+			allowed = 0
+	if globalVars.config.get("multicastAlarm", "multicastAlarm_ric"):
+		if poc_id in globalVars.config.get("multicastAlarm", "multicastAlarm_ric"):
+			logging.info("RIC %s as multicastAlarm message", poc_id)
+			return True
+		else:
+			allowed = 0
 
 	if allowed == 0:
 		return False
 	return True
-
 ##
 #
 # POCSAG decoder function


### PR DESCRIPTION
…_delimiter_ric and multicastAlarm_ric no longer need to be included in allow_ric or filter_range_start/filter_range_end.

wegen https://github.com/Schrolli91/BOSWatch/issues/355 bzw. https://boswatch.de/index.php?thread/36-multicastalarm-rics-aus-den-filter/