### PR TITLE
Clear buffer after multicastAlarm_ric received

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ##### Changed
 - multicastAlarm Plugin - RICs die von multicastAlarm genutzt werden, müssen nicht mehr in der config bei allow_ric bzw. filter_range_start/filter_range_end berücksichtigt werden. [#357](https://github.com/Schrolli91/BOSWatch/pull/357)
 - FFAgent Plugin - Debug Logging für die alarmHeaders eingebaut zwecks Troubleshooting [#354](https://github.com/Schrolli91/BOSWatch/pull/354)
+- multicastAlarm Plugin - Buffer nach jedem Alarm löschen - erlaubt in kombination mit "doubleFilter_check_msg" die Verwendung in Netzen, die zwischen multicastAlarm RICs auch normale Alarme senden. #370(https://github.com/Schrolli91/BOSWatch/pull/370)
 ##### Deprecated
 ##### Removed
 ##### Fixed

--- a/config/config.template.ini
+++ b/config/config.template.ini
@@ -144,7 +144,7 @@ multicastAlarm = 0
 # time limit for alarms that do not belong to the multicastAlarm sequence in seconds
 multicastAlarm_ignore_time = 15
 
-# multicastAlarm delimiter RIC (usually used as a starting point for a alarm sequence) (can be empty)
+# multicastAlarm delimiter RIC (usually used as a starting point for a alarm sequence). Needs to be empty if multicastAlarms are interrupted by normal alarms.
 multicastAlarm_delimiter_ric =
 
 # multicastAlarm RIC that is used to send the text message

--- a/includes/multicastAlarm.py
+++ b/includes/multicastAlarm.py
@@ -58,6 +58,8 @@ def multicastAlarmExec(freq, data):
 		try:
 			from includes import alarmHandler
 			alarmHandler.processAlarmHandler("POC", freq, data)
+			multiList = []
+			logging.debug("multicastAlarm finished - buffer cleared")
 		except:
 			logging.error("processing alarm failed")
 			logging.debug("processing alarm failed", exc_info=True)

--- a/includes/multicastAlarm.py
+++ b/includes/multicastAlarm.py
@@ -58,8 +58,8 @@ def multicastAlarmExec(freq, data):
 		try:
 			from includes import alarmHandler
 			alarmHandler.processAlarmHandler("POC", freq, data)
-			del multiList[:]
-			logging.debug("multicastAlarm finished - buffer cleared")
 		except:
 			logging.error("processing alarm failed")
 			logging.debug("processing alarm failed", exc_info=True)
+		del multiList[:]
+		logging.debug("multicastAlarm finished - buffer cleared")

--- a/includes/multicastAlarm.py
+++ b/includes/multicastAlarm.py
@@ -29,7 +29,7 @@ def newEntrymultiList(data):
 	timestamp = int(time.time())
 	# multicastAlarm processing if enabled and delimiter RIC has been received
 	if data['ric'] == globalVars.config.get("multicastAlarm", "multicastAlarm_delimiter_ric"):
-		multiList = []
+		del multiList[:]
 		logging.debug("delimiter RIC received - buffer cleared")
 	else:
 		multiList.append([data, timestamp])
@@ -58,7 +58,7 @@ def multicastAlarmExec(freq, data):
 		try:
 			from includes import alarmHandler
 			alarmHandler.processAlarmHandler("POC", freq, data)
-			multiList = []
+			del multiList[:]
 			logging.debug("multicastAlarm finished - buffer cleared")
 		except:
 			logging.error("processing alarm failed")

--- a/includes/multicastAlarm.py
+++ b/includes/multicastAlarm.py
@@ -61,5 +61,5 @@ def multicastAlarmExec(freq, data):
 		except:
 			logging.error("processing alarm failed")
 			logging.debug("processing alarm failed", exc_info=True)
-		del multiList[:]
-		logging.debug("multicastAlarm finished - buffer cleared")
+	del multiList[:]
+	logging.debug("multicastAlarm finished - buffer cleared")


### PR DESCRIPTION
Fix for networks that mix normal alarms with multicastAlarms (delimiter needs to be deactivated) and require a large value for the multicastAlarm_ignore_time.
If the delimiter is deactivated, RICs in the buffer will be deleted only if they are older than multicastAlarm_ignore_time. This could cause a mixture of RICs of the current and the privious multicastAlarm. This problem can be fixed, by clearing the buffer after the multicastAlarm sequence has finished.
