### PR TITLE
GPIO Control

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### __[v2.4.4]__ - unreleased
 ##### Added
 - Divera-Plugin: Plugin zum Ansteuern der Divera-Api. [#415](https://github.com/Schrolli91/BOSWatch/pull/415)
+- GPIO-Control: Plugin zum Ansteuern der GPIO Pins. [#438](https://github.com/Schrolli91/BOSWatch/pull/438)
 ##### Changed
 - MySQL-Plugin: Index für die RIC Adresse hinzugefügt [#411](https://github.com/Schrolli91/BOSWatch/issues/411)
 - MySQL-Plugin: INSERT Befehl für MySQL 8.x angepasst, Spaltennamen escaped [#410](https://github.com/Schrolli91/BOSWatch/issues/410)

--- a/config/config.template.ini
+++ b/config/config.template.ini
@@ -175,6 +175,7 @@ Pushover = 0
 Telegram = 0
 yowsup = 0
 hue = 0
+gpiocontrol = 0
 
 # for developing - template-module
 template = 0
@@ -462,6 +463,18 @@ timeon = 2
 timeoff = 1
 # configure 0 to keep the switch on for infinite time or configure >=1 to keep it for the value in seconds to on, before switching to off.
 keepon = 60
+
+[gpiocontrol]
+#Pin that will be triggered
+#Only tested on Raspberry Pi 3
+pin = 21
+
+#Time the Pin will be triggered (in Seconds)
+triggertime = 180
+
+#ONLY POC
+#POC Rics that trigger PIN (empty: allow all, separator ",")
+activerics = 1234567,1234568
 
 #####################
 ##### Not ready yet #

--- a/plugins/gpiocontrol/gpiocontrol.py
+++ b/plugins/gpiocontrol/gpiocontrol.py
@@ -42,7 +42,7 @@ def onLoad():
 	global waitTime
 
 	GPIOPIN = globalVars.config.getint("gpiocontrol","pin")
-	waitTime = globalVars.config.getint("gpiocontrol","ontime")
+	waitTime = globalVars.config.getint("gpiocontrol","triggertime")
 
 	GPIO.setmode(GPIO.BCM)
 	GPIO.setwarnings(False)
@@ -79,7 +79,7 @@ def run(typ,freq,data):
 		if configHandler.checkConfig("gpiocontrol"): #read and debug the config (let empty if no config used)
 
 			logging.debug(globalVars.config.get("gpiocontrol", "pin"))
-			logging.debug(globalVars.config.get("gpiocontrol", "ontime"))
+			logging.debug(globalVars.config.get("gpiocontrol", "triggertime"))
 
 			########## User Plugin CODE ##########
 			if typ == "FMS":

--- a/plugins/gpiocontrol/gpiocontrol.py
+++ b/plugins/gpiocontrol/gpiocontrol.py
@@ -83,19 +83,23 @@ def run(typ,freq,data):
 
 			########## User Plugin CODE ##########
 			if typ == "FMS":
-				#th = threading.Thread(target = trigger)
-				#th.start()
-				logging.warning("%s not supported", typ)
+				th = threading.Thread(target = trigger)
+				th.start()
+				#logging.warning("%s not supported", typ)
 			elif typ == "ZVEI":
-				#th = threading.Thread(target = trigger)
-				#th.start()
-				logging.warning("%s not supported", typ)
+				th = threading.Thread(target = trigger)
+				th.start()
+				#logging.warning("%s not supported", typ)
 			elif typ == "POC":
-				if  data["ric"] in globalVars.config.get("gpiocontrol", "activerics"):
-					th = threading.Thread(target = trigger)
-                               		th.start()
-				else:
-					logging.info("Ric not in activerics")
+				if globalVars.config.get("gpiocontrol", "activerics") == "":
+                    		th = threading.Thread(target = trigger)
+                    		th.start()
+              			else
+                 			if  data["ric"] in globalVars.config.get("gpiocontrol", "activerics"):
+                				th = threading.Thread(target = trigger)
+                    				th.start()
+                    			else:
+                        			logging.info("Ric not in activerics")
 			else:
 				logging.warning("Invalid Typ: %s", typ)
 			########## User Plugin CODE ##########

--- a/plugins/gpiocontrol/gpiocontrol.py
+++ b/plugins/gpiocontrol/gpiocontrol.py
@@ -1,0 +1,87 @@
+#!/usr/bin/python
+# -*- coding: UTF-8 -*-
+
+# Imports
+
+import RPi.GPIO as GPIO
+import time
+import threading
+
+import logging # Global logger
+from includes import globalVars  # Global variables
+
+# Helper function, uncomment to use
+from includes.helper import timeHandler
+from includes.helper import wildcardHandler
+from includes.helper import configHandler
+
+##
+#
+# onLoad (init) function of plugin
+# will be called one time by the pluginLoader on start
+#
+def onLoad():
+	"""
+	While loading the plugins by pluginLoader.loadPlugins()
+	this onLoad() routine is called one time for initialize the plugin
+	"""
+	global GPIOPIN
+	global waitTime
+    
+	GPIOPIN = globalVars.config.getint("gpiocontrol","pin")
+	waitTime = globalVars.config.getint("gpiocontrol","triggertime")
+    
+
+	GPIO.setmode(GPIO.BCM)
+	GPIO.setwarnings(False)
+	GPIO.setup(GPIOPIN, GPIO.OUT)
+  	GPIO.output(GPIOPIN, GPIO.HIGH)
+
+	return
+
+#
+#
+# Main function of plugin
+# will be called by the alarmHandler
+#
+def run(typ,freq,data):
+	try:
+		if configHandler.checkConfig("gpiocontrol"): #read and debug the config
+
+			logging.debug(globalVars.config.get("gpiocontrol", "pin"))
+			logging.debug(globalVars.config.get("gpiocontrol", "triggertime"))
+   			logging.debug(globalVars.config.get("gpiocontrol", "activerics"))
+            
+			########## User Plugin CODE ##########
+			if typ == "FMS":
+				th = threading.Thread(target = trigger)
+                        	th.start()
+			elif typ == "ZVEI":
+				th = threading.Thread(target = trigger)
+                        	th.start()
+			elif typ == "POC":
+                		if globalVars.config.get("gpiocontrol", "activerics") == "":
+                    		th = threading.Thread(target = trigger)
+                    		th.start()
+              			else
+                 			if  data["ric"] in globalVars.config.get("gpiocontrol", "activerics"):
+                				th = threading.Thread(target = trigger)
+                    				th.start()
+                    			else:
+                        			logging.info("Ric not in activerics")
+			else:
+                    		logging.warning("Invalid Typ: %s", typ)
+			########## User Plugin CODE ##########
+
+	except:
+		logging.error("unknown error")
+		logging.debug("unknown error", exc_info=True)
+
+def trigger():
+	GPIO.output(GPIOPIN, GPIO.LOW)
+	logging.info("GPIOPIN %s on", GPIOPIN)
+	time.sleep(waitTime)
+  	GPIO.output(GPIOPIN, GPIO.HIGH)
+	logging.info("GPIOPIN %s off", GPIOPIN)
+
+	return


### PR DESCRIPTION
Bisher funktioniert:

- GPIO Pin auswählen
- Bei einem Alarm wird der GPIO Pin für die in der Config eingetragene Zeit aktiviert und anschließend deaktiviert
- Für POC: Plugin reagiert (nur) auf die in der Config eingetragenden PINS

ToDo:

- Aktive RICS für FMS und ZVEI anpassen