### PR TITLE
MySQL plugin: Ensure correct charset and collaction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 ##### Deprecated
 ##### Removed
 ##### Fixed
-- MySQL plugin: Ensure character set (utf8mb4) and collation (utf8mb4_general_ci) are set correctly when connection to database is established.
+- MySQL plugin: Ensure character set (utf8mb4) and collation (utf8mb4_general_ci) are set correctly when connection to database is established. [#447](https://github.com/Schrolli91/BOSWatch/pull/447)
 ##### Security
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ##### Deprecated
 ##### Removed
 ##### Fixed
+- MySQL plugin: Ensure character set (utf8mb4) and collation (utf8mb4_general_ci) are set correctly when connection to database is established.
 ##### Security
 
 

--- a/plugins/MySQL/MySQL.py
+++ b/plugins/MySQL/MySQL.py
@@ -91,7 +91,7 @@ def run(typ,freq,data):
 				# Connect to MySQL
 				#
 				logging.debug("connect to MySQL")
-				connection = mysql.connector.connect(host = globalVars.config.get("MySQL","dbserver"), port = globalVars.config.get("MySQL","dbport"), user = globalVars.config.get("MySQL","dbuser"), passwd = globalVars.config.get("MySQL","dbpassword"), db = globalVars.config.get("MySQL","database"), charset='utf8mb4')
+				connection = mysql.connector.connect(host = globalVars.config.get("MySQL","dbserver"), port = globalVars.config.get("MySQL","dbport"), user = globalVars.config.get("MySQL","dbuser"), passwd = globalVars.config.get("MySQL","dbpassword"), db = globalVars.config.get("MySQL","database"), charset = 'utf8mb4', collation = 'utf8mb4_general_ci')
 				cursor = connection.cursor()
 			except:
 				logging.error("cannot connect to MySQL")


### PR DESCRIPTION
Ensure character set (utf8mb4) and collation (utf8mb4_general_ci) are set correctly when connection to database is established, see #445.