### PR TITLE
Namensvergabe POC nur für einzelne Sub-RICs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ### __[v2.5.1]__ - unreleased
 ##### Added
 - Plugin requirements: Added requirements.txt for all plugins requiring extra python packages so the install will be easier 
-- POC: neuer Parameter um Sub-RICs ohne Hauptdefinition zu beschreiben. Parameter 'onlysubric'. [#449](https://github.com/Schrolli91/BOSWatch/pull/449)
+- DescriptionList POC: add new description parameter for Sub-RICs without a main RIC definition. parameter 'onlysubric'. [#449](https://github.com/Schrolli91/BOSWatch/pull/449)
 ##### Changed
 ##### Deprecated
 ##### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### __[v2.5.1]__ - unreleased
 ##### Added
 - Plugin requirements: Added requirements.txt for all plugins requiring extra python packages so the install will be easier 
+- POC: neuer Parameter um Sub-RICs ohne Hauptdefinition zu beschreiben. Parameter 'onlysubric'. [#449](https://github.com/Schrolli91/BOSWatch/pull/449)
 ##### Changed
 ##### Deprecated
 ##### Removed

--- a/config/config.template.ini
+++ b/config/config.template.ini
@@ -103,8 +103,8 @@ filter_range_end =   9999999
 # descriptions are loaded from csv/poc.csv
 idDescribed = 0
 
-# Main-RIC with Subric (0 - off)
-# Only Sub-RIC (1 - on)
+# change between Main-RIC with Sub-RIC (0 - off)
+# or only the Sub-RIC (1 - on)
 # descriptions are loaded from csv/poc.csv
 onlysubric = 0
 

--- a/config/config.template.ini
+++ b/config/config.template.ini
@@ -103,6 +103,11 @@ filter_range_end =   9999999
 # descriptions are loaded from csv/poc.csv
 idDescribed = 0
 
+# Main-RIC with Subric (0 - off)
+# Only Sub-RIC (1 - on)
+# descriptions are loaded from csv/poc.csv
+onlysubric = 0
+
 # Static Massages for Subrics.
 rica = Feuer
 ricb = TH

--- a/csv/poc.template.csv
+++ b/csv/poc.template.csv
@@ -5,11 +5,17 @@ ric,description
 # For each RIC-Address you could set a description-text
 # Use the structure: ric,"Description-Text"
 #
+# main RIC with subric:
 # You can even define specific subrics, therefore you
 # 1. need to specify a main RIC: 1234567, "Unit One"
 # 2. specify a certain subric: 1234567B, "Subunit Bravo"
 # The result for 1234567B will be "Unit One Subunit Bravo"
 # - Be sure having defined the main RIC (step one)! -
+#
+# Only subric:
+# Specify only the subric: 123457B, "Subunit Bravo"
+# The result for 1234567B will be "Subunit Bravo"
+# - main RIC is not required -
 #
 # !!! DO NOT delete the first line !!!
 #

--- a/includes/descriptionList.py
+++ b/includes/descriptionList.py
@@ -110,6 +110,9 @@ def getDescription(typ, data):
 		elif typ == "ZVEI":
 			resultStr = zveiDescribtionList[data]
 		elif typ == "POC":
+			if globalVars.config.getint("POC", "onlysubric"):
+				resultStr = ricDescribtionList[data] # only SubRIC
+			else:        
 			resultStr = ricDescribtionList[data[:-1]] # MainRIC
 			resultStr += " " + ricDescribtionList[data] # SubRIC
 		else:

--- a/includes/descriptionList.py
+++ b/includes/descriptionList.py
@@ -112,9 +112,9 @@ def getDescription(typ, data):
 		elif typ == "POC":
 			if globalVars.config.getint("POC", "onlysubric"):
 				resultStr = ricDescribtionList[data] # only SubRIC
-			else:        
-			resultStr = ricDescribtionList[data[:-1]] # MainRIC
-			resultStr += " " + ricDescribtionList[data] # SubRIC
+			else:
+				resultStr = ricDescribtionList[data[:-1]] # MainRIC
+				resultStr += " " + ricDescribtionList[data] # SubRIC
 		else:
 			logging.warning("Invalid Typ: %s", typ)
 


### PR DESCRIPTION
Anpassung der Namensvergabe im POC-Template:

- Main-RIC mit Sub-RIC
- nur Sub-RIC
in der Beschriftung.

Hintergrund: Bei uns im Kreis werden nur einzelne Sub-RICs zur Alarmierung weitergeleitet. Die main-RIC wird in dem Fall nicht benötigt. Daher soll es die Möglichkeit geben, selber zu entscheiden, ob nur "onlysubrics" eingeschaltet werden soll.