### PR TITLE
POC Text anhand Regex auswerten

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 
 ### __[v2.5.3]__ - unreleased
 ##### Added
-- Extending POC data-structure by Regex named groups matching.
+- Extending POC data-structure by Regex named groups matching. [#508](https://github.com/Schrolli91/BOSWatch/pull/508)
 ##### Changed
 ##### Deprecated
 ##### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 
 ### __[v2.5.3]__ - unreleased
 ##### Added
+- Extending POC data-structure by Regex named groups matching.
 ##### Changed
 ##### Deprecated
 ##### Removed

--- a/config/config.template.ini
+++ b/config/config.template.ini
@@ -136,7 +136,7 @@ geo_order = LON, lon, LAT, lat
 # {'function': '1', 'has_geo': False, 'description': '1234567', 'has_schema_fields': False, 'msg': 'TESTALARM Person in Zwangslage;H2.04;Neustadt;Königsbach;Weinstraße 1;VS Winzerheim;;Dortige Baustelle..Treppensturz', 'bitrate': 1200, 'ric': '1234567'}
 #
 # When using the schemaRegex from below, data will look like this:
-# {'function': '1', 'has_geo': False, 'description': '1234567', 'has_schema_fields': True, 'msg': 'TESTALARM Person in Zwangslage;H2.04;Neustadt;Königsbach;Weinstraße 1;VS Winzerheim;;Dortige Baustelle..Treppensturz', 'bitrate': 1200, 'ric': '1234567, 'Objekt': 'VS Winzerheim', 'StichwortLang': 'TESTALARM Person in Zwangslage', 'Ort': 'Neustadt', 'Bemerkung1': '', 'Adresse': 'Weinstraße 1', 'Bemerkung2': 'Dortige Baustelle..Treppensturz', 'StichwortKurz': 'H2.04', 'Ortsteil': 'Königsbach'
+# {'function': '1', 'has_geo': False, 'description': '1234567', 'has_schema_fields': True, 'msg': 'TESTALARM Person in Zwangslage;H2.04;Neustadt;Königsbach;Weinstraße 1;VS Winzerheim;;Dortige Baustelle..Treppensturz', 'bitrate': 1200, 'ric': '1234567, 'Objekt': 'VS Winzerheim', 'StichwortLang': 'TESTALARM Person in Zwangslage', 'Ort': 'Neustadt', 'Bemerkung1': '', 'Adresse': 'Weinstraße 1', 'Bemerkung2': 'Dortige Baustelle..Treppensturz', 'StichwortKurz': 'H2.04', 'Ortsteil': 'Königsbach'}
 #
 # Attention: If you define named groups with names of fields that that are already present in POC decoder's standard data-structure, the content of the respective fields will be overwritten
 # with data evaluated by this regex (if the regex finds a match). E.g. if you define a named group like "...(?P<ric>.*)..." and the regex will be hit,

--- a/config/config.template.ini
+++ b/config/config.template.ini
@@ -127,6 +127,9 @@ geo_enable = 0
 geo_format = #C(\d{2})(\d{5}),(\d{2})(\d{5})#
 geo_order = LON, lon, LAT, lat
 
+# Analyze message and associate data to named fields
+schemaRegex = ^(?P<StichwortLang>.*?);(?P<StichwortKurz>.*?);(?P<Ort>.*?);(?P<Ortsteil>.*?);(?P<Adresse>.*?);(?P<Objekt>.*?);(?P<Bemerkung1>.*?);(?P<Bemerkung2>.*?)$
+
 
 [multicastAlarm]
 # Configure multicastAlarm if your POCSAG network uses an optimized transmission scheme for alarms with more than one RIC (often found in Swissphone networks).

--- a/config/config.template.ini
+++ b/config/config.template.ini
@@ -128,7 +128,7 @@ geo_format = #C(\d{2})(\d{5}),(\d{2})(\d{5})#
 geo_order = LON, lon, LAT, lat
 
 # Analyze message and associate data to named fields
-schemaRegex = ^(?P<StichwortLang>.*?);(?P<StichwortKurz>.*?);(?P<Ort>.*?);(?P<Ortsteil>.*?);(?P<Adresse>.*?);(?P<Objekt>.*?);(?P<Bemerkung1>.*?);(?P<Bemerkung2>.*?)$
+#schemaRegex = ^(?P<StichwortLang>.*?);(?P<StichwortKurz>.*?);(?P<Ort>.*?);(?P<Ortsteil>.*?);(?P<Adresse>.*?);(?P<Objekt>.*?);(?P<Bemerkung1>.*?);(?P<Bemerkung2>.*?)$
 
 
 [multicastAlarm]

--- a/config/config.template.ini
+++ b/config/config.template.ini
@@ -128,6 +128,19 @@ geo_format = #C(\d{2})(\d{5}),(\d{2})(\d{5})#
 geo_order = LON, lon, LAT, lat
 
 # Analyze message and associate data to named fields
+# If the regular expression matches the POC message, the "named groups" defined in schemaRegex will be added to the data structure.
+# You can check this by looking at the value in data["has_schema_fields"]. If it is True, then the regular expression has been hit and the additional fields are available.
+# E.g. POC message is "TESTALARM Person in Zwangslage;H2.04;Neustadt;Königsbach;Weinstraße 1;VS Winzerheim;;Dortige Baustelle..Treppensturz"
+#
+# Without the schemaRegex, data will look like this (RIC, SubRIC and Bitrate are random):
+# {'function': '1', 'has_geo': False, 'description': '1234567', 'has_schema_fields': False, 'msg': 'TESTALARM Person in Zwangslage;H2.04;Neustadt;Königsbach;Weinstraße 1;VS Winzerheim;;Dortige Baustelle..Treppensturz', 'bitrate': 1200, 'ric': '1234567'}
+#
+# When using the schemaRegex from below, data will look like this:
+# {'function': '1', 'has_geo': False, 'description': '1234567', 'has_schema_fields': True, 'msg': 'TESTALARM Person in Zwangslage;H2.04;Neustadt;Königsbach;Weinstraße 1;VS Winzerheim;;Dortige Baustelle..Treppensturz', 'bitrate': 1200, 'ric': '1234567, 'Objekt': 'VS Winzerheim', 'StichwortLang': 'TESTALARM Person in Zwangslage', 'Ort': 'Neustadt', 'Bemerkung1': '', 'Adresse': 'Weinstraße 1', 'Bemerkung2': 'Dortige Baustelle..Treppensturz', 'StichwortKurz': 'H2.04', 'Ortsteil': 'Königsbach'
+#
+# Attention: If you define named groups with names of fields that that are already present in POC decoder's standard data-structure, the content of the respective fields will be overwritten
+# with data evaluated by this regex (if the regex finds a match). E.g. if you define a named group like "...(?P<ric>.*)..." and the regex will be hit,
+# then data["ric"] will get filled with the content evaluated by the regex.
 #schemaRegex = ^(?P<StichwortLang>.*?);(?P<StichwortKurz>.*?);(?P<Ort>.*?);(?P<Ortsteil>.*?);(?P<Adresse>.*?);(?P<Objekt>.*?);(?P<Bemerkung1>.*?);(?P<Bemerkung2>.*?)$
 
 

--- a/includes/decoders/poc.py
+++ b/includes/decoders/poc.py
@@ -164,12 +164,12 @@ def decode(freq, decoded):
 							logging.debug("schemaRegex found")
 							m = re.match(globalVars.config.get("POC", "schemaRegex"), poc_text)
 							if m:
-								logging.info("POC Schema match")
+								logging.debug("POC Schema match")
 								# enrich data structure by regex groups
 								data.update(m.groupdict())
 								data["has_schema_fields"] = True
 							else:
-								logging.info("No POC Schema match")
+								logging.debug("No POC Schema match")
 						
 						if has_geo == True:
 							data["lon"] = lon

--- a/includes/decoders/poc.py
+++ b/includes/decoders/poc.py
@@ -157,7 +157,20 @@ def decode(freq, decoded):
 
 					# check for double alarm
 					if doubleFilter.checkID("POC", poc_id+poc_sub, poc_text):
-						data = {"ric":poc_id, "function":poc_sub, "msg":poc_text, "bitrate":bitrate, "description":poc_id, "has_geo":has_geo}
+						data = {"ric":poc_id, "function":poc_sub, "msg":poc_text, "bitrate":bitrate, "description":poc_id, "has_geo":has_geo, "has_schema_fields":False}
+						
+						# if a schema is defined, analyze and associate
+						if globalVars.config.has_option("POC", "schemaRegex"):
+							logging.info("schemaRegex found")
+							m = re.match(globalVars.config.get("POC", "schemaRegex"), poc_text)
+							if m:
+								logging.info("POC Schema match")
+								# enrich data structure by regex groups
+								data.update(m.groupdict())
+								data["has_schema_fields"] = True
+							else:
+								logging.info("No POC Schema match")
+						
 						if has_geo == True:
 							data["lon"] = lon
 							data["lat"] = lat
@@ -177,7 +190,7 @@ def decode(freq, decoded):
 							logging.debug(" - multicastAlarm without msg")
 							from includes import multicastAlarm
 							multicastAlarm.newEntrymultiList(data)
-
+						
 						# multicastAlarm processing if enabled and alarm message has been received
 						elif globalVars.config.getint("multicastAlarm", "multicastAlarm") and data["msg"] != "" and data["ric"] in globalVars.config.get("multicastAlarm", "multicastAlarm_ric"):
 							logging.debug(" - multicastAlarm with message")

--- a/includes/decoders/poc.py
+++ b/includes/decoders/poc.py
@@ -161,7 +161,7 @@ def decode(freq, decoded):
 						
 						# if a schema is defined, analyze and associate
 						if globalVars.config.has_option("POC", "schemaRegex"):
-							logging.info("schemaRegex found")
+							logging.debug("schemaRegex found")
 							m = re.match(globalVars.config.get("POC", "schemaRegex"), poc_text)
 							if m:
 								logging.info("POC Schema match")


### PR DESCRIPTION
Hi, ich habe eine Konfigurationsoption für den POC Decoder eingebaut, so dass der Text anhand eines regulären Ausdrucks mit Angabe von "named groups" analysiert und die data-Struktur entsprechend angereichert werden kann. Hat den Vorteil, dass wenn es ein festgelegtes Schema im Alarmierungstext gibt, die einzelnen Elemente in den entsprechenden Plugins dediziert weiterverwendet werden können.

Ob ein Text nach dem Schema ausgewertet konnte und es es die zusätzlichen Felder in der data-Struktur gibt, zeigt das Element has_schema_fields in der data-Struktur (True oder False).