### PR TITLE
Bugfixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 ##### Deprecated
 ##### Removed
 ##### Fixed
+ - Use specific mysql-connector-python version 8.0.19 [#533](https://github.com/Schrolli91/BOSWatch/pull/533)
+ - Correct Syntax-Errors in MySQL Statements [#533](https://github.com/Schrolli91/BOSWatch/pull/533)
 ##### Security
 
 

--- a/install.sh
+++ b/install.sh
@@ -187,7 +187,7 @@ echo "[ 8/9] [########-]"
 tput cup 15 5
 echo "-> Download & Install MySQL connector for Python."
 cd $boswatch_install_path
-pip install mysql-connector-python >> $boswatch_install_path/setup_log.txt 2>&1
+pip install mysql-connector-python==8.0.19 >> $boswatch_install_path/setup_log.txt 2>&1
 exitcodefunction $? install mysql-connector
 
 # Blacklist DVB-Drivers

--- a/plugins/MySQL/boswatch.sql
+++ b/plugins/MySQL/boswatch.sql
@@ -25,8 +25,8 @@ SET time_zone = "+00:00";
 -- Datenbank anlegen `boswatch`
 --
 
-CREATE DATABASE IF NOT EXISTS 'boswatch' DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
-USE 'boswatch';
+CREATE DATABASE IF NOT EXISTS `boswatch` DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+USE `boswatch`;
 
 -- --------------------------------------------------------
 


### PR DESCRIPTION
Während der Installation der Datenbank kam es zu Fehlern.
Escaping der Tabelle ist fehlerhaft.
Es wird eine spezielle mysql-connector-python Version benötigt.