### PR TITLE
added possibility to configure login data for mqtt broker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ##### Added
 - Functionality to fill coordinate values in POC data structure (lat, lon) based on configured locations that match a regular expression in POC message [#510](https://github.com/Schrolli91/BOSWatch/pull/510)
 - Extending POC data-structure by Regex named groups matching. [#508](https://github.com/Schrolli91/BOSWatch/pull/508)
+- MQTT Plugin: Added possibility to configure login (user and password) for mqtt broker. [#539](https://github.com/Schrolli91/BOSWatch/pull/539)
 ##### Changed
 ##### Deprecated
 ##### Removed

--- a/config/config.template.ini
+++ b/config/config.template.ini
@@ -596,6 +596,9 @@ commandPOC =
 #Adress from MQTT-Broker
 brokeraddress = 192.168.178.27
 topic = alarm/data
+# username and password for the broker. leave username empty to use anonymous login
+brokerusername = 
+brokerpassword = 
 
 #####################
 ##### Not ready yet #

--- a/plugins/mqtt/mqtt.py
+++ b/plugins/mqtt/mqtt.py
@@ -77,7 +77,11 @@ def run(typ,freq,data):
 			########## User Plugin CODE ##########
 			broker_address = globalVars.config.get("mqtt", "brokeraddress")
 			topic = globalVars.config.get("mqtt", "topic")
-			mqttClient = mqtt.Client()
+
+            broker_username = globalVars.config.get("mqtt", "brokerusername")
+            broker_password = globalVars.config.get("mqtt", "brokerpassword")
+
+            mqttClient = mqtt.Client()
 
 			if typ == "FMS":
 				x = {
@@ -112,6 +116,12 @@ def run(typ,freq,data):
 				logging.warning("Invalid Typ: %s", typ)
 			
 			y = json.dumps(x)
+
+
+            ## only login if there is a username given
+            if( len(broker_username) > 0 ):
+                mqttClient.username_pw_set(broker_username, broker_password)
+
 			mqttClient.connect(broker_address)
 			mqttClient.publish(topic,y)
 			########## User Plugin CODE ##########


### PR DESCRIPTION
Since anonymous login does not work for my mqtt broker, I added the possibility to configure login data for the broker.
This time using develop branch :)